### PR TITLE
Hide unnecessary UI clutter

### DIFF
--- a/srv/stirling-pdf/stirling-pdf/customFiles/templates/fragments/footer.html
+++ b/srv/stirling-pdf/stirling-pdf/customFiles/templates/fragments/footer.html
@@ -1,2 +1,9 @@
 <footer th:fragment="footer" id="footer">
+  <script>
+    // Remove "Upgrade to Pro" button
+    if(document.querySelector(".go-pro-link")) document.querySelector(".go-pro-link").parentElement.remove();
+
+    // Hide "New and recently updated" section
+    if(document.getElementById("groupRecent")) document.getElementById("groupRecent").style.display = "none";
+  </script>
 </footer>


### PR DESCRIPTION
Hide the following:

- "Upgrade to Pro" button
- "New and recently updated" section on landing page

Using inline JavaScript because this is very simple and inline JS is allowed by Content-Security-Policy anyway.